### PR TITLE
organize type interfaces

### DIFF
--- a/components/Logout.tsx
+++ b/components/Logout.tsx
@@ -3,11 +3,6 @@ import { Redirect } from "expo-router";
 import { MaterialIcons } from "@expo/vector-icons";
 import { useSessionContext } from "@/context/sessionContext";
 
-interface LogoutProps {
-	size: number;
-	color: string;
-}
-
 export default function Logout({ size, color }: LogoutProps) {
 	const { signOut } = useSessionContext();
 

--- a/components/SettingDeleteButton.tsx
+++ b/components/SettingDeleteButton.tsx
@@ -1,10 +1,5 @@
 import { StyleSheet, TouchableOpacity, Text } from "react-native";
 
-interface SettingDeleteButtonProps {
-	isDeleting: boolean;
-	confirmDelete: () => void;
-}
-
 export default function SettingDeleteButton({
 	isDeleting,
 	confirmDelete,

--- a/components/TransactionItemModal.tsx
+++ b/components/TransactionItemModal.tsx
@@ -8,12 +8,7 @@ import {
 	Alert,
 } from "react-native";
 import { useTransactionsContext } from "@/context/transactionsContext";
-
-interface TransactionItemModalProps {
-	modalVisible: boolean;
-	setModalVisible: (visible: boolean) => void;
-	selectedTransaction: TransactionItem;
-}
+import { useFormatDate } from "@/hooks/useFormatDate";
 
 export default function TransactionItemModal({
 	modalVisible,
@@ -21,14 +16,7 @@ export default function TransactionItemModal({
 	selectedTransaction,
 }: TransactionItemModalProps) {
 	const { deleteTransaction, getTransactions } = useTransactionsContext();
-
-	function formatDate(dateString: Date | string) {
-		const date = new Date(dateString);
-		const day = date.getDate();
-		const month = date.toLocaleString("default", { month: "short" });
-		const year = date.getFullYear();
-		return `${month} ${day}, ${year}`;
-	}
+	const { formatDate } = useFormatDate();
 
 	async function hanadleDelete() {
 		Alert.alert(

--- a/hooks/useGetCategories.tsx
+++ b/hooks/useGetCategories.tsx
@@ -1,14 +1,6 @@
 import { useState, useEffect } from "react";
 import { supabase } from "@/lib/supabase";
 
-interface CategoryState {
-	categories: Category[];
-	loading: boolean;
-	error: Error | null;
-}
-
-type selectedCategory = Category | null;
-
 export function useGetCategories() {
 	const [categoryState, setCategoryState] = useState<CategoryState>({
 		categories: [],

--- a/types/contextType.d.ts
+++ b/types/contextType.d.ts
@@ -1,0 +1,24 @@
+interface SessionContextType {
+	session: Session | null;
+	signInWithEmail: (email: string) => Promise<void>;
+	signOut: () => Promise<void>;
+}
+
+interface TransactionsContextType {
+	transactions: TransactionItem[];
+	transactionItem: TransactionItem;
+	modalVisible: boolean;
+	datePickerConfig: DatePickerConfig;
+	setModalVisible: (visible: boolean) => void;
+	showDatepicker: () => void;
+	// biome-ignore lint/suspicious/noExplicitAny: <explanation>
+	onDateChange: (_: any, selectedDate?: Date) => void;
+	updateTransaction: (
+		field: keyof TransactionItem,
+		value: string | number,
+	) => void;
+	resetTransaction: () => void;
+	AddTransaction: () => Promise<void>;
+	deleteTransaction: (id: string) => Promise<void>;
+	getTransactions: () => void;
+}

--- a/types/expenseTracker.d.ts
+++ b/types/expenseTracker.d.ts
@@ -1,71 +1,5 @@
-interface SessionContextType {
-	session: Session | null;
-	signInWithEmail: (email: string) => Promise<void>;
-	signOut: () => Promise<void>;
-}
-
-interface TransactionsContextType {
-	transactions: TransactionItem[];
-	transactionItem: TransactionItem;
-	modalVisible: boolean;
-	datePickerConfig: DatePickerConfig;
-	setModalVisible: (visible: boolean) => void;
-	showDatepicker: () => void;
-	// biome-ignore lint/suspicious/noExplicitAny: <explanation>
-	onDateChange: (_: any, selectedDate?: Date) => void;
-	updateTransaction: (
-		field: keyof TransactionItem,
-		value: string | number,
-	) => void;
-	resetTransaction: () => void;
-	AddTransaction: () => Promise<void>;
-	deleteTransaction: (id: string) => Promise<void>;
-	getTransactions: () => void;
-}
-
-interface ChildrenProps {
-	children: React.ReactNode;
-}
-
-interface ColorsContextType {
-	colors: {
-		primary: {
-			darkBlue: string;
-			mediumBlue: string;
-			lightBlue: string;
-		};
-		secondary: {
-			skyBlue: string;
-			paleBlue: string;
-			navyBlue: string;
-		};
-		accent: {
-			teal: string;
-			coral: string;
-			lavender: string;
-		};
-		neutral: {
-			lightGray: string;
-			mediumGray: string;
-			darkGray: string;
-		};
-		notification: {
-			yellow: string;
-			green: string;
-			coral: string;
-		};
-	};
-}
-
-interface TransactionItemProps {
-	isIncome: boolean;
-	name: string;
-	category: string;
-	amountText: string;
-	id: string;
-}
-
 type ModeTypes = "date" | "time" | "datetime" | "countdown";
+type selectedCategory = Category | null;
 
 interface TransactionItem {
 	id: string;
@@ -87,12 +21,10 @@ interface Category {
 	category_name: string;
 }
 
-interface CategoryDropdownProps {
+interface CategoryState {
 	categories: Category[];
 	loading: boolean;
 	error: Error | null;
-	selectedCategory: Category | null;
-	onSelect: (category: Category) => void;
 }
 
 interface Profile {

--- a/types/propType.d.ts
+++ b/types/propType.d.ts
@@ -1,0 +1,34 @@
+interface ChildrenProps {
+	children: React.ReactNode;
+}
+
+interface TransactionItemProps {
+	isIncome: boolean;
+	category: string;
+	amountText: string;
+	id: string;
+}
+
+interface CategoryDropdownProps {
+	categories: Category[];
+	loading: boolean;
+	error: Error | null;
+	selectedCategory: Category | null;
+	onSelect: (category: Category) => void;
+}
+
+interface TransactionItemModalProps {
+	modalVisible: boolean;
+	setModalVisible: (visible: boolean) => void;
+	selectedTransaction: TransactionItem;
+}
+
+interface LogoutProps {
+	size: number;
+	color: string;
+}
+
+interface SettingDeleteButtonProps {
+	isDeleting: boolean;
+	confirmDelete: () => void;
+}


### PR DESCRIPTION
closes #25 

- **split type files into general, context and props**
- **move interfaces to their type files**
- **move interface to prop type and get formatDate from useFormatDate hook** (this close issue 25)
